### PR TITLE
Generalize bisg inputs

### DIFF
--- a/R/bisg.R
+++ b/R/bisg.R
@@ -202,7 +202,9 @@ compute_p_r_cond_s <- function(
   surname_col,
   surname_counts = NULL,
   surname_col_counts = "surname",
-  race_cols = c("whi", "bla", "his", "asi", "oth")) {
+  race_cols = c("whi", "bla", "his", "asi", "oth"),
+  impute_missing = TRUE
+  ) {
 
   # If no surname table given, use wru default
   if (is.null(surname_counts)) {
@@ -238,6 +240,13 @@ compute_p_r_cond_s <- function(
         y = surname_counts,
         by = stats::setNames(surname_col_counts, surname_col)
       )
+
+    # Fill in missing names with mean probability across all surnames
+    # (surnames weighted equally!)
+    if (impute_missing) {
+      p_r_s[which(is.na(p_r_s[[race_cols[1]]])), race_cols] <-
+        colMeans(surname_counts[,race_cols])
+    }
   }
   return(p_r_s)
 }

--- a/man/bisg.Rd
+++ b/man/bisg.Rd
@@ -9,12 +9,13 @@ bisg(
   voter_file,
   surname_col,
   geo_col,
-  census_counts = NULL,
+  geo_counts = NULL,
   geography = NULL,
   state = NULL,
   county = NULL,
   year = NULL,
   geo_col_counts = "fips",
+  surname_col_counts = "surname",
   race_cols = c("whi", "bla", "his", "asi", "oth"),
   impute_missing = TRUE,
   verbose = FALSE,
@@ -30,7 +31,7 @@ column that denotes their surname.}
 \item{geo_col}{A string denoting which column contains the geographic unit
 ID.}
 
-\item{census_counts}{A tibble containing counts (divided amongst constituent
+\item{geo_counts}{A tibble containing counts (divided amongst constituent
 groups) per geographic units (rows). If NULL, these counts will be obtained
 using the eiCompare helper function and the other parameters.}
 
@@ -49,6 +50,9 @@ data. Otherwise, uses the 5-year ACS summary data.}
 \item{geo_col_counts}{A string denoting the column in the counts tibble that
 refers to the geographic unit.}
 
+\item{surname_col_counts}{A string denoting the column in the surname_counts
+tibble that refers to the geographic unit.}
+
 \item{race_cols}{A list of strings denoting the columns containing racial
 groups.}
 
@@ -60,6 +64,13 @@ broader geographic unit.}
 \item{verbose}{A boolean denoting the verbosity.}
 
 \item{cache}{A boolean denoting whether Census data should be cached.}
+
+\item{surname_counts}{A dataframe denoting the frequency with which surnames
+correspond to different race/ethnicities. If NULL, the Census surname list is
+ used with categories and merging functions from wru. The dataframe should
+contain one column with surnames (specified with the y surname_col_counts
+parameter) and one column for each race/ethnicity group (specified with the
+race_cols parameter).}
 }
 \value{
 A tibble with rows denoting voters and columns denoting the

--- a/man/bisg.Rd
+++ b/man/bisg.Rd
@@ -10,6 +10,7 @@ bisg(
   surname_col,
   geo_col,
   geo_counts = NULL,
+  surname_counts = NULL,
   geography = NULL,
   state = NULL,
   county = NULL,
@@ -34,6 +35,13 @@ ID.}
 \item{geo_counts}{A tibble containing counts (divided amongst constituent
 groups) per geographic units (rows). If NULL, these counts will be obtained
 using the eiCompare helper function and the other parameters.}
+
+\item{surname_counts}{A dataframe denoting the frequency with which surnames
+correspond to different race/ethnicities. If NULL, the Census surname list is
+ used with categories and merging functions from wru. The dataframe should
+contain one column with surnames (specified with the y surname_col_counts
+parameter) and one column for each race/ethnicity group (specified with the
+race_cols parameter).}
 
 \item{geography}{The geographic level at which to obtain Census data. If
 obtaining data from the decennial Census, can be up to "block". If
@@ -64,13 +72,6 @@ broader geographic unit.}
 \item{verbose}{A boolean denoting the verbosity.}
 
 \item{cache}{A boolean denoting whether Census data should be cached.}
-
-\item{surname_counts}{A dataframe denoting the frequency with which surnames
-correspond to different race/ethnicities. If NULL, the Census surname list is
- used with categories and merging functions from wru. The dataframe should
-contain one column with surnames (specified with the y surname_col_counts
-parameter) and one column for each race/ethnicity group (specified with the
-race_cols parameter).}
 }
 \value{
 A tibble with rows denoting voters and columns denoting the

--- a/man/compute_p_g_cond_r.Rd
+++ b/man/compute_p_g_cond_r.Rd
@@ -5,10 +5,10 @@
 \title{Computes the probability a person is in a specific geographic unit,
 conditioned on a racial group.}
 \usage{
-compute_p_g_cond_r(counts, cols = c("whi", "bla", "his", "asi", "oth"))
+compute_p_g_cond_r(geo_counts, cols = c("whi", "bla", "his", "asi", "oth"))
 }
 \arguments{
-\item{counts}{A tibble containing counts (divided amongst constituent groups)
+\item{geo_counts}{A tibble containing counts (divided amongst constituent groups)
 per geographic units (rows).}
 
 \item{cols}{The columns denoting the constituent groups within each

--- a/man/compute_p_r_cond_s.Rd
+++ b/man/compute_p_r_cond_s.Rd
@@ -10,7 +10,8 @@ compute_p_r_cond_s(
   surname_col,
   surname_counts = NULL,
   surname_col_counts = "surname",
-  race_cols = c("whi", "bla", "his", "asi", "oth")
+  race_cols = c("whi", "bla", "his", "asi", "oth"),
+  impute_missing = TRUE
 )
 }
 \arguments{

--- a/man/compute_p_r_cond_s.Rd
+++ b/man/compute_p_r_cond_s.Rd
@@ -5,13 +5,29 @@
 \title{Computes the probability a person is of a specific racial group, conditioned
 on surname.}
 \usage{
-compute_p_r_cond_s(voter_file, surname_col)
+compute_p_r_cond_s(
+  voter_file,
+  surname_col,
+  surname_counts = NULL,
+  surname_col_counts = "surname",
+  race_cols = c("whi", "bla", "his", "asi", "oth")
+)
 }
 \arguments{
 \item{voter_file}{A tibble containing a list of voters (by row), and a
 column that denotes their surname.}
 
 \item{surname_col}{A string denoting which column contains the voter surname.}
+
+\item{surname_counts}{A dataframe denoting the frequency with which surnames
+correspond to different race/ethnicities. If NULL, the Census surname list is
+ used with categories and merging functions from wru. The dataframe should
+contain one column with surnames (specified with the y surname_col_counts
+parameter) and one column for each race/ethnicity group (specified with the
+race_cols parameter).}
+
+\item{surname_col_counts}{A string denoting the column in the surname_counts
+tibble that refers to the geographic unit.}
 }
 \value{
 A tibble with rows denoting voters and columns denoting the

--- a/man/compute_p_r_cond_s_g.Rd
+++ b/man/compute_p_r_cond_s_g.Rd
@@ -20,6 +20,9 @@ compute_p_r_cond_s_g(
 \item{voter_file}{A tibble containing a list of voters (by row), and a
 column that denotes their surname.}
 
+\item{geo_counts}{A tibble containing counts (divided amongst constituent groups)
+per geographic units (rows).}
+
 \item{surname_col}{A string denoting which column contains the voter surname.}
 
 \item{geo_col}{A string denoting which column contains the geographic unit
@@ -40,9 +43,6 @@ that refers to the geographic unit.}
 
 \item{surname_col_counts}{A string denoting the column in the surname_counts
 tibble that refers to the geographic unit.}
-
-\item{counts}{A tibble containing counts (divided amongst constituent groups)
-per geographic units (rows).}
 }
 \value{
 A tibble with rows denoting voters and columns denoting the

--- a/man/compute_p_r_cond_s_g.Rd
+++ b/man/compute_p_r_cond_s_g.Rd
@@ -7,35 +7,42 @@ on surname and geolocation.}
 \usage{
 compute_p_r_cond_s_g(
   voter_file,
-  counts,
+  geo_counts,
   surname_col,
   geo_col,
+  surname_counts = NULL,
   race_cols = c("whi", "bla", "his", "asi", "oth"),
   geo_col_counts = "fips",
-  p_r_s = NULL
+  surname_col_counts = "surname"
 )
 }
 \arguments{
 \item{voter_file}{A tibble containing a list of voters (by row), and a
 column that denotes their surname.}
 
-\item{counts}{A tibble containing counts (divided amongst constituent groups)
-per geographic units (rows).}
-
 \item{surname_col}{A string denoting which column contains the voter surname.}
 
 \item{geo_col}{A string denoting which column contains the geographic unit
 ID.}
 
+\item{surname_counts}{A dataframe denoting the frequency with which surnames
+correspond to different race/ethnicities. If NULL, the Census surname list is
+ used with categories and merging functions from wru. The dataframe should
+contain one column with surnames (specified with the y surname_col_counts
+parameter) and one column for each race/ethnicity group (specified with the
+race_cols parameter).}
+
 \item{race_cols}{A list of strings denoting the columns containing racial
 groups.}
 
-\item{geo_col_counts}{A string denoting the column in the counts tibble that
-refers to the geographic unit.}
+\item{geo_col_counts}{A string denoting the column in the geo_counts tibble
+that refers to the geographic unit.}
 
-\item{p_r_s}{A dataframe denoting the probability of race conditioned on
-surname that matches with the provided voter file. Can accelerate
-computation if provided up front.}
+\item{surname_col_counts}{A string denoting the column in the surname_counts
+tibble that refers to the geographic unit.}
+
+\item{counts}{A tibble containing counts (divided amongst constituent groups)
+per geographic units (rows).}
 }
 \value{
 A tibble with rows denoting voters and columns denoting the

--- a/tests/testthat/test_bisg.R
+++ b/tests/testthat/test_bisg.R
@@ -1,0 +1,42 @@
+context("Test main BISG function")
+
+test_that("BISG probabilities are computed correctly with custom inputs", {
+
+  # Basic lookups
+  surname_counts <- data.frame(
+    "surname" = c("x", "y"),
+    "w" = c(1, 2),
+    "b" = c(2, 3)
+  )
+  geo_counts <- data.frame(
+    "fips" = c("a", "b"),
+    "w" = c(1, 3),
+    "b" = c(2, 3)
+  )
+  # Raw data
+  data <- data.frame(
+    "fips" = c("a"),
+    "surname" = c("x")
+  )
+
+  # Do BISG manually
+  p_r_cond_s <- surname_counts[,c("w","b")]/rowSums(surname_counts[,c("w","b")])
+  p_s_cond_g <- t(t(geo_counts[,c("w", "b")])/colSums(geo_counts[,c("w", "b")]))
+  probs <- p_r_cond_s[which(surname_counts$surname == "x"),]*
+           p_s_cond_g[which(geo_counts$fips == "a"),]
+  probs <- probs/rowSums(probs)
+
+  # Now do it with the function
+  probs_bisg <- bisg(
+    voter_file = data,
+    geo_col = "fips",
+    geo_counts = geo_counts,
+    geo_col_counts = "fips",
+    surname_col = "surname",
+    surname_counts = surname_counts,
+    surname_col_counts = "surname",
+    race_cols = c("w", "b")
+  )
+
+  expect_equal(probs, probs_bisg[1, c("w", "b")])
+})

--- a/tests/testthat/test_bisg.R
+++ b/tests/testthat/test_bisg.R
@@ -15,16 +15,21 @@ test_that("BISG probabilities are computed correctly with custom inputs", {
   )
   # Raw data
   data <- data.frame(
-    "fips" = c("a"),
-    "surname" = c("x")
+    "fips" = c("a", "b"),
+    "surname" = c("x", "z")
   )
 
-  # Do BISG manually
+  # Do BISG manually for first row of data
   p_r_cond_s <- surname_counts[,c("w","b")]/rowSums(surname_counts[,c("w","b")])
-  p_s_cond_g <- t(t(geo_counts[,c("w", "b")])/colSums(geo_counts[,c("w", "b")]))
-  probs <- p_r_cond_s[which(surname_counts$surname == "x"),]*
-           p_s_cond_g[which(geo_counts$fips == "a"),]
-  probs <- probs/rowSums(probs)
+  p_g_cond_r <- t(t(geo_counts[,c("w", "b")])/colSums(geo_counts[,c("w", "b")]))
+  prob1 <- p_r_cond_s[which(surname_counts$surname == "x"),]*
+    p_g_cond_r[which(geo_counts$fips == "a"),]
+  prob1 <- as.numeric(prob1/rowSums(prob1))
+
+  # Now for second row with NA
+  prob2 <- colMeans(p_r_cond_s)*p_g_cond_r[which(geo_counts$fips == "b"),]
+  prob2 <- as.numeric(prob2/sum(prob2))
+
 
   # Now do it with the function
   probs_bisg <- bisg(
@@ -38,5 +43,6 @@ test_that("BISG probabilities are computed correctly with custom inputs", {
     race_cols = c("w", "b")
   )
 
-  expect_equal(probs, probs_bisg[1, c("w", "b")])
+  expect_equal(prob1, as.numeric(probs_bisg[1, c("w", "b")]))
+  expect_equal(prob2, as.numeric(probs_bisg[2, c("w", "b")]))
 })

--- a/tests/testthat/test_utils.R
+++ b/tests/testthat/test_utils.R
@@ -1,10 +1,10 @@
 context("Test BISG utility functions.")
 
 test_that("swap_census_geography operates correctly", {
-    expect_equal("block group", eiCompare::swap_census_geography("block"))
-    expect_equal("tract", eiCompare::swap_census_geography("block group"))
-    expect_equal("county", eiCompare::swap_census_geography("tract"))
-    expect_equal("state", eiCompare::swap_census_geography("county"))
-    expect_equal("block group", eiCompare::swap_census_geography("block"))
-    expect_error(eiCompare::swap_census_geography("test"))
+    expect_equal("block group", bisg::swap_census_geography("block"))
+    expect_equal("tract", bisg::swap_census_geography("block group"))
+    expect_equal("county", bisg::swap_census_geography("tract"))
+    expect_equal("state", bisg::swap_census_geography("county"))
+    expect_equal("block group", bisg::swap_census_geography("block"))
+    expect_error(bisg::swap_census_geography("test"))
 })


### PR DESCRIPTION
Addressing #5.  Adds
* Enables the use of custom surname lookup tables. 
* Some basic tests that `bisg` outputs the correct results when using custom lookups for surname and geography.
* Handles unknown surnames in the custom table by taking the unweighted mean probability across the table
